### PR TITLE
Ros2 interface additions - extra suggestions

### DIFF
--- a/dev/source/docs/ros2-interfaces.rst
+++ b/dev/source/docs/ros2-interfaces.rst
@@ -196,6 +196,12 @@ For more information on the coordinate systems used, review `ROS REP-105 <https:
    </tbody>
    </table>
 
+.. warning:: 
+   Only the dynamic transformations on ``/ap/tf`` that have parent_frame ``odom`` and child_frame ``base_link`` are fed into ``AP_VisualOdom``. 
+   Other frame configurations will be gracefully ignored, so feel free to populate this topic with other transforms if that's convenient.
+
+For more information on how to setup ArduPilot with an external odometry source, 
+see the :ref:`cartographer SLAM example<ros2-cartographer-slam>.
 
 Configuring Interfaces at Compile Time
 ======================================

--- a/dev/source/docs/ros2-interfaces.rst
+++ b/dev/source/docs/ros2-interfaces.rst
@@ -70,6 +70,11 @@ Pose, Rates, and Coordinates
    <td>This is the filtered AHRS's velocity in the local ENU frame relative to home.</td>
    </tr>
    <tr>
+   <td>ap/pose/filtered</td>
+   <td>geometry_msgs/msg/PoseStamped</td> 
+   <td>This is the filtered AHRS's pose in the local ENU frame relative to home.</td>
+   </tr>
+   <tr>
    <td>ap/geopose/filtered</td>
    <td>geographic_msgs/msg/GeoPoseStamped</td> 
    <td>This is the filtered AHRS's pose (position+orientation) in global coordinates</td>

--- a/dev/source/docs/ros2-interfaces.rst
+++ b/dev/source/docs/ros2-interfaces.rst
@@ -244,6 +244,6 @@ If breaking changes are required, the ArduPilot release notes will make that cle
 Developers should not expect ABI stability on ``exerimental`` interfaces.
 
 Because ArduPilot does not follow the same release timeline as ROS 2, and
-the development team for the ROS interface still in its early stages,
+the development team for the ROS interface is still in its early stages,
 ArduPilot does not yet support a stable ABI across multiple ROS distributions.
 The current ROS version supported is ``humble``.


### PR DESCRIPTION
# Purpose
Suggest minor changes for PR ardupilot/ardupilot_wiki#6343.

# Additional notes
I have some extra documentation on `tf` trees from my GSoC project, but since your PR is focused on documenting `AP_DDS` I'm not sure if this is this wiki page is adequate for it, what do you think ? @Ryanf55  
A possible source of confusion regarding `tf` trees is that `ardupilot_gz` launches end up creating two different `tf` trees. 

Theres the `ros_gz` `/gz/tf` topic, which I tried to use in GSoC 2023 and failed due to it not following [ROS REP 105](https://www.ros.org/reps/rep-0105.html):
![image](https://github.com/user-attachments/assets/392e2d6b-85fd-406a-993e-69c160ebf33d)

So, in order to have a working tree, `robot_state_publisher` was used to generate this [REP 105](https://www.ros.org/reps/rep-0105.html) compliant tree:
![image](https://github.com/user-attachments/assets/121ec425-f778-483a-9625-f80d8715d432)

Which works perfectly when adding cartographer as a `map` -> `odom` -> `base_link` source.
![image](https://github.com/user-attachments/assets/5bdc15c2-3d72-4a60-9926-783f54c4ef1e)

What worries me about putting this in the wiki is that `robot_state_publisher` depends on the `robot_description` of each robot, so the picture might be misleading.